### PR TITLE
Fix course filter bar overflow on mobile and mid-width screens

### DIFF
--- a/static/css/base58-staging-site-02.webflow.css
+++ b/static/css/base58-staging-site-02.webflow.css
@@ -5262,3 +5262,48 @@ figcaption {
   }
 }
 
+/* Course filter bar fixes */
+
+/* below 1440px the single-row filter bar doesn't fit; stack it like the tablet layout */
+@media screen and (min-width: 992px) and (max-width: 1439px) {
+  .filters5_feed-header-top._2 {
+    grid-row-gap: 1rem;
+    grid-template-rows: auto auto;
+    grid-template-columns: 1fr max-content;
+  }
+
+  #w-node-_65af496a-32b2-8454-891b-4860bad7b0ee-c60f7abd {
+    grid-area: 2 / 1 / 3 / 3;
+  }
+
+  #w-node-_407a40df-a809-97c6-e402-8f5ecf39cb32-c60f7abd {
+    grid-area: 1 / 2 / 2 / 3;
+  }
+}
+
+/* on phones stack the filter controls in a single column so nothing overflows the viewport */
+@media screen and (max-width: 767px) {
+  /* minmax(0, 1fr) lets the dropdown shrink on narrow phones; its text truncates with ellipsis */
+  .filters5_feed-header-top._2 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  #w-node-_407a40df-a809-97c6-e402-8f5ecf39cb32-c60f7abd {
+    grid-area: 2 / 1 / 3 / 2;
+    justify-self: start;
+    max-width: 100%;
+  }
+
+  #w-node-_65af496a-32b2-8454-891b-4860bad7b0ee-c60f7abd {
+    grid-area: 3 / 1 / 4 / 2;
+    max-width: 100%;
+  }
+
+  .dropdown1_toggle,
+  .dropdown1_toggle .filter-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+

--- a/templates/courses.tmpl
+++ b/templates/courses.tmpl
@@ -72,7 +72,8 @@
     .course_filters .tab4_tabs-menu {
       justify-content: center;
     }
-    @media screen and (min-width: 992px) {
+    /* single-row filter bar only fits >=1440px; below that the stacked layout applies */
+    @media screen and (min-width: 1440px) {
       .course_filters .filters5_feed-header-top._2 {
         grid-template-areas: none !important;
         grid-template-rows: auto !important;


### PR DESCRIPTION
On the `/courses` page the filter bar was breaking at certain screen sizes. On phones the page overflowed horizontally, so you could scroll into a white strip and the content looked cut off. On desktop windows narrower than ~1440px the sort dropdown rendered on top of the "Experienced" tab.

The single row layout for the filter bar only fits on wide screens, so now it applies from 1440px up. Below that the bar stacks the same way the tablet layout already did, and on phones the dropdown shrinks with ellipsis instead of widening the page.

### Before
Desktop
<img width="1423" height="569" alt="image" src="https://github.com/user-attachments/assets/b4c3ac64-7f9f-497f-9da3-a7e9e5653011" />
Mobile
<img width="306" height="586" alt="image" src="https://github.com/user-attachments/assets/b0468183-69f4-415b-aad5-e43d14001db0" />


### After
Desktop
<img width="1417" height="583" alt="image" src="https://github.com/user-attachments/assets/c42db782-9772-4a75-92ac-9884c634453f" />
Mobile
<img width="268" height="551" alt="image" src="https://github.com/user-attachments/assets/256ec352-9899-4f46-8429-d6128cee1b93" />
